### PR TITLE
Organized Coniditions

### DIFF
--- a/rules-topics/19_status-effects.md
+++ b/rules-topics/19_status-effects.md
@@ -46,84 +46,95 @@ Shattering or destroying containers that contain things does NOT affect the item
 Skilless refers to any abilities purchased with Skill Points.  You do not lose any Armor or Health Points gained from purchased skills.
 
 
-## Status Effects
+## Ability
 
 ---
 | Term| Description|Encounter Call  |Visible?|
 |:---|---|:-----------------------------------------------:|:---:|
 | ACID SPITTLE| Ability user's ranged attacks deal x Acid Damage.  |  X Acid| No |
 | AETHER| Ability user's attacks cannot be blocked, resisted, reflected, or in any way defended against.  |  Aether X| No |
-| ANIMATE  | Target takes UNDEAD effect and is unable to use skills, communicate, or move faster than walk.  | Varies by source. |Yes |
 | AURA  | Ability user may swing <x> as their damage type | Varies by source. | No |
-| BERSERK  | Ability user gains x damage against one target and becomes immune to fear and charming effects for y time.  Ability user may not retreat while Berserking.  |Berserk|Yes |
-| BLEED | Target is unable to be healed for x time. | Varies by source. |Yes |
-| BLEED OUT| Target is in BLEED OUT status and has -1 HP/body.  Unless the effect is ended, after 1 minute, target will take DEAD status.| None  | No |
-| BLIND | Target is unable to use skills and attacks that require range beyond touch.| Varies by source. | No |
 | BLINK | Ability user teleports to a location specified by the caster.  User must have been physically present in the location previously.| Blink |Yes |
-| CONCENTRATION  | Ability user is unable to communicate, use skills, items, abilities, hold a shield, or move faster than walk for duration of effect.| None  |Yes |
-| CONFINE  | Target is bound by the called skill for x time and may not attack, block, or drop held items.| Varies by source. |Yes |
-| CONFUSE  | Target is disoriented and cannot tell allies from enemies, but is not forced to attack.| Varies by source. |Yes |
-| CONSCIOUS| Target in this status has at least 1 HP/body.| Varies by source. |Yes |
 | CORROSIVE| Ability user causes all tagged items that make physical contact are destroyed (as per shatter/destroy) at the end of the encounter  |  OOC  | No |
-| CURSE | Target receives double damage.|(Type) Curse | No |
-| CURSE OF TRANSFORMATION | Target becomes X creature and is given stats and directions by Marshal or caster upon. Removal methods vary.| Killing Blow 1, 2, 3, Curse of Transformation X | No |
 | DAMAGE CAP X| Ability user is only hit for maximum of x damage.  |Minimal| No |
-| DEAD  | Target is in Dead status and target's spirit will dissipate and may seek resurrection after 5 minutes unless effect is ended by REVIVE or LIFE effects.  | Varies by source. |Yes |
-| DEATH | Target immediately takes DEAD status.  | Varies by source. | No |
-| DECIMATE | Target takes DEAD status upon receiving this effect.  If target dissipates and resurrects, target incurs double Strain. (4 Total)|  (Type) Decimate  | No |
 | DESTROY  | Target is destroyed after x time.| Varies by source. |Yes |
-| DISARM| Target must drop any x item for x time.| Varies by source. |Yes |
-| DODGE | Ability user may resist more than one type of effect, and so dodges it. | Dodge | No |
-| DOOM  | Target is reduced to -1 HP/body. | Varies by source. | No |
 | DOUBLE DAMAGE  | Ability user does double damage for x type.  | Harm Double | Not Applicable |
-| DRAINED  | Target is skilless.  |(Type) Drain | No |
 | ENDURE| At 59 seconds of BLEED OUT status, ability user is restored to 1 HP/Body.  Requires 1 minute of CONCENTRATION by ability user. |  Endurance  | Not Applicable |
-| ENGULF| Target and possessions are eaten and target must stand to side OOC.  Target is reduced to -1 HP/body and takes BLEED OUT status.  Target is released upon death of creature.  |1 I engulf you, 2... 3...|Yes |
-| ENSLAVEMENT | Target is compelled to follow any instructions given by ability user.| Varies by source. | No |
-| ENTANGLE | Target is entangled at the x location for y time.  | Entangle X  |Yes |
 | EXCEPTIONAL STRENGTH | Ability user gains +1 Damage for each level of Exceptional Strength. | None  | No |
-| FEAR  | Target is unable to attack and will attempt to leave the area for x time.  | Varies by source. |Yes |
 | GASEOUS | Ability user becomes gaseous and cannot be affected by anything except SOLIDIFY. |1 I go gaseous, 2... 3...|Yes |
 | HEALED BY| Ability user is healed by x type/effect.  |Appears to Heal Me |Yes |
 | HIVE MIND| Ability user may hear Hive Mind communication.  |Hive Mind <Phrase> | No |
 | IMMUNITY | Ability user immune to x effect for y time.  |  No Effect  | Not Applicable |
 | INCORPOREAL | Ability user is immune to non-magical damage.|  N/A  |Yes |
-| INERT | Target unable to use or cast x for y time.||  No|  |
 | INFECT| Ability user may infect a target and inflict them with x effect.  |1 I infect you, 2... 3...| Not Applicable |
-| INVULNERABLE| Ability user is immune to all spells, physical attacks, and toxin for x time. | Varies by source. |Yes |
-| KNEEL | Target must kneel or crouch and cross their dominant hand over their chest.  Target may otherwise attack and defend normally. | Varies by source. |Yes |
-| LIFE  | Target with DEAD status is healed to full HP/body and all status effects are removed.  | Varies by source. |Yes |
 | MAGIC DELIVERANCE | Ability user may cast spells without incants.|Magic X| Not Applicable |
-| MUMMY CURSE | Target immediately dissipates and seeks resurrection. |  Killing Blow 1, 2, 3, Mummy Curse  | No |
 | NATURAL ARMOR  | Ability user has armor that does not have to be physically represented. |  N/A  |Yes |
 | OVERWHELMING STRENGTH| Ability user swings for Vital damage. Damage from user is always taken unless target makes a defensive call.|  N/A  | No |
 | POSSESSION  | Ability user goes OOC, but may voice control the target. Acts as per ENSLAVEMENT.|  1 I possess you, 2... 3...| No |
-| PRESERVE | Target in DEAD status has their Death count halted for x time.  May only be done once. | Varies by source. | No |
 | REDUCE | Ability user takes half damage from x effect, rounded up.|Reduce| No |
-| REFLECT  | Ability user may reflect x ability.  The reflected ability may be resisted, but may not be reflected again. | Varies by source. | Not Applicable |
 | REGENERATE  | Ability user with CONSCIOUS status restores full HP/body after 1 minute of CONCENTRATION effect. | Regenerating / Regenerate Complete  |Yes ||
-| RESIST| Ability user resists x effect.|Resist | Not Applicable |
 | REVIVE| Unless target was affected by <x> within 20 seconds of becoming Dead, or was Killing Blowed at any time by <x>, then at 4 minutes 59 seconds of Death count, instead of dissipating, the player announces "Revive" and the target is healed to full HP/body and all status effects are removed. |Revive | No |
 | RIFT  | Ability user teleports to a location specified by the caster.  User must have been physically present in the location previously.|1 I Rift, 2... 3...|Yes |
-| RIFT LOCK | Prevents the target from using any RIFT abilities for x time.|N/A|No| 
 | RIP FREE | Ability user may escape ENTANGLE effects. |  1 I Rip free, 2.. 3..  | Not Applicable |
+| SPIRIT BOTTLE  | Ability user dissipates at 0 HP/body instead of taking UNCONSCIOUS status and reforms at the location of their spirit bottle.  Ability user suffers no Strain.  Spirit bottle is destroyed after x uses. |  N/A  | No |
+| THRESHOLD| Ability user only takes minimum damage for any damage taken equal to or less than x.|Minimal| No |
+| VOICE CONTROL  | Target is compelled to follow any instructions given by ability user |  Voice Control X  | No |
+| X TO HIT | Ability user is immune to all weapons except x type.  |  No Effect  | No |
+
+## Status
+
+---
+| Term| Description|Encounter Call  |Visible?|
+|:---|---|:-----------------------------------------------:|:---:|
+| ANIMATE  | Target takes UNDEAD effect and is unable to use skills, communicate, or move faster than walk.  | Varies by source. |Yes |
+| BERSERK  | Ability user gains x damage against one target and becomes immune to fear and charming effects for y time.  Ability user may not retreat while Berserking.  |Berserk|Yes |
+| BLEED | Target is unable to be healed for x time. | Varies by source. |Yes |
+| BLEED OUT| Target is in BLEED OUT status and has -1 HP/body.  Unless the effect is ended, after 1 minute, target will take DEAD status.| None  | No |
+| BLIND | Target is unable to use skills and attacks that require range beyond touch.| Varies by source. | No |
+| CONCENTRATION  | Ability user is unable to communicate, use skills, items, abilities, hold a shield, or move faster than walk for duration of effect.| None  |Yes |
+| CONFINE  | Target is bound by the called skill for x time and may not attack, block, or drop held items.| Varies by source. |Yes |
+| CONFUSE  | Target is disoriented and cannot tell allies from enemies, but is not forced to attack.| Varies by source. |Yes |
+| CONSCIOUS| Target in this status has at least 1 HP/body.| Varies by source. |Yes |
+| CURSE | Target receives double damage.|(Type) Curse | No |
+| CURSE OF TRANSFORMATION | Target becomes X creature and is given stats and directions by Marshal or caster upon. Removal methods vary.| Killing Blow 1, 2, 3, Curse of Transformation X | No |
+| DEAD  | Target is in Dead status and target's spirit will dissipate and may seek resurrection after 5 minutes unless effect is ended by REVIVE or LIFE effects.  | Varies by source. |Yes |
+| DISARM| Target must drop any x item for x time.| Varies by source. |Yes |
+| DRAINED  | Target is skilless. Target may not make active use of skills, granted or otherwise  |(Type) Drain | No |
+| ENGULF| Target and possessions are eaten and target must stand to side OOC.  Target is reduced to -1 HP/body and takes BLEED OUT status.  Target is released upon death of creature.  |1 I engulf you, 2... 3...|Yes |
+| ENSLAVEMENT | Target is compelled to follow any instructions given by ability user.| Varies by source. | No |
+| ENTANGLE | Target is entangled at the x location for y time.  | Entangle X  |Yes |
+| FEAR  | Target is unable to attack and will attempt to leave the area for x time.  | Varies by source. |Yes |
+| INERT | Target unable to use or cast x for y time.||  No|  |
+| INVULNERABLE| Ability user is immune to all spells, physical attacks, and toxin for x time. | Varies by source. |Yes |
+| KNEEL | Target must kneel or crouch and cross their dominant hand over their chest.  Target may otherwise attack and defend normally. | Varies by source. |Yes |
+| PRESERVE | Target in DEAD status has their Death count halted for x time.  May only be done once. | Varies by source. | No |
+| RIFT LOCK | Prevents the target from using any RIFT abilities for x time.|N/A|No| 
 | SILENCE  | Target is unable to speak in game.  May make game system calls.| Varies by source. |Yes |
 | SLEEP | Target must be prone or crouched and cannot communicate or use skills or items.  | Varies by source. | No |
 | SLOW  | Target is unable to run for x time. | Varies by source. |Yes |
-| SOLIDIFY | Ability user or Target's GASEOUS effect is removed. | Varies by source. | Not Applicable |
-| SPELLSTRIKE | Ability user may deliver a spell with a physical weapon. |Spellstrike (Spell Name) | Not Applicable |
-| SPIRIT BOTTLE  | Ability user dissipates at 0 HP/body instead of taking UNCONSCIOUS status and reforms at the location of their spirit bottle.  Ability user suffers no Strain.  Spirit bottle is destroyed after x uses. |  N/A  | No |
 | STAGGER  | Target must retreat x steps, if able.  May attack and defend while retreating.| Varies by source. |Yes |
 | STASIS | Target may not move, communicate in any manner, activate items, or use any game skills for duration.  Target does not take damage and cannot be moved.  Target may choose to end the effect early.| Varies by source. |Yes|
-| STONE | Target takes DEAD status immediately.  Target cannot be moved. | Varies by source. |Yes |
 | STOP THRUST | Target unable to advance into combat for x time.| Varies by source. |Yes |
 | STUN  | Target may not move, communicate in any manner, activate items, or use game skills for x time.  Damage does not remove effect. | Varies by source. |Yes |
 | SUICIDE  | Allows creature to die and dissipate at will regardless of other status effects. | 1 I suicide, 2... 3...  | Not Applicable |
 | TELEPORT BLOCK | Target is prevented from moving by any form of magical travel for x time.  | Varies by source. | No |
-| THRESHOLD| Ability user only takes minimum damage for any damage taken equal to or less than x.|Minimal| No |
 | UNCONSCIOUS | Target must be prone or crouched and cannot communicate or use skills or items.  Target has 0 HP/body for 5 minutes, after which target will take CONSCIOUS status and restore to 1 HP/body.  If target takes damage while in UNCONSCIOUS status, target's health becomes -1 HP/body and target takes BLEED OUT status immediately. | Varies by source. | No |
 | UNDEAD| Target is visibly a lesser undead, may talk, move, and use skills for x time. | Varies by source. |Yes |
-| VOICE CONTROL  | Target is compelled to follow any instructions given by ability user |  Voice Control X  | No |
-| VOICE RADIUS| All targets that hear the call take X effect.|  Voice Radius X| No |
 | WEAKEN| Target damage is lowered by x amount for y time.| Varies by source. | No |
-| X TO HIT | Ability user is immune to all weapons except x type.  |  No Effect  | No |
+ 
+## Effects
+
+---
+| Term| Description|Encounter Call  |Visible?|
+|:---|---|:-----------------------------------------------:|:---:|
+| DEATH | Target immediately takes DEAD status.  | Varies by source. | No |
+| DECIMATE | Target takes DEAD status upon receiving this effect.  If target dissipates and resurrects, target incurs double Strain. (4 Total)|  (Type) Decimate  | No |
+| DODGE | Ability user may resist more than one type of effect, and so dodges it. | Dodge | No |
+| DOOM  | Target is reduced to -1 HP/body. | Varies by source. | No |
+| LIFE  | Target with DEAD status is healed to full HP/body and all status effects are removed.  | Varies by source. |Yes |
+| MUMMY CURSE | Target immediately dissipates and seeks resurrection. |  Killing Blow 1, 2, 3, Mummy Curse  | No |
+| REFLECT  | Ability user may reflect x ability.  The reflected ability may be resisted, but may not be reflected again. | Varies by source. | Not Applicable |
+| RESIST| Ability user resists x effect.|Resist | Not Applicable |
+| SOLIDIFY | Ability user or Target's GASEOUS effect is removed. | Varies by source. | Not Applicable |
+| SPELLSTRIKE | Ability user may deliver a spell with a physical weapon. |Spellstrike (Spell Name) | Not Applicable |
+| VOICE RADIUS| All targets that hear the call take X effect.|  Voice Radius X| No |

--- a/rules-topics/19_status-effects.md
+++ b/rules-topics/19_status-effects.md
@@ -51,7 +51,6 @@ Skilless refers to any abilities purchased with Skill Points.  You do not lose a
 ---
 | Term| Description|Encounter Call  |Visible?|
 |:---|---|:-----------------------------------------------:|:---:|
-| ACID SPITTLE| Ability user's ranged attacks deal x Acid Damage.  |  X Acid| No |
 | AETHER| Ability user's attacks cannot be blocked, resisted, reflected, or in any way defended against.  |  Aether X| No |
 | AURA  | Ability user may swing <x> as their damage type | Varies by source. | No |
 | BLINK | Ability user teleports to a location specified by the caster.  User must have been physically present in the location previously.| Blink |Yes |


### PR DESCRIPTION
First I would suggest that the section be renamed Coniditions as to encapsulate its variety of effects, status, and abilities

This reorganizes all of the status sections into 3 separate tables for readability, organization, and understandability: Ability, Status, and Effect 

Ability: 
These are conditions or rules the subject is under that would cause them to be treated differently from a standard adventurer. EG you can hit something with a sword unless they are incorporeal.

Status: 
These are conditions that last longer than a moment and affect a subject for a time. EG for the duration of fear you must run away.

Effect: 
These conditions are resolved immediately and have no lasting impact beyond their consequences. EG Death while setting the dead status itself does not persist beyond that.

ENGULF and CURSE OF TRANSFORMATION are put under status because while a creature can apply them, their wording only talks about how they affect the specific target.

 A reworked drain description that should make it clear Conjure Weapon or equivalents do not bypass this status.

I was told by Lapis to remove the stone status.