### PR TITLE
Mimicry update

### DIFF
--- a/rules-topics/08_agility-skills.md
+++ b/rules-topics/08_agility-skills.md
@@ -9,7 +9,7 @@
 
 
 ## Mimicry
-> This skill allows the user to use any single Spell or Stamina ability once per purchase of Mimicry.  The user must additionally expend a number of Agility Points equal to double the mimicked ability's Mana or Stamina cost, as appropriate. Use requires the verbal:  My turn!  <ability verbal/incant>
+> This skill allows the user to use any single Spell or Stamina ability once per purchase of Mimicry.  The user must additionally expend a number of Agility Points equal to double the mimicked ability's Mana or Stamina cost, as appropriate.  Mimicry cannot be used on level 10 Spells.  Use requires the verbal:  My turn!  <ability verbal/incant>
 
 |Mimicry Point Costs|F|T|R|M|
 |---|---|---|---|---|

--- a/rules-topics/999_changelog.md
+++ b/rules-topics/999_changelog.md
@@ -41,6 +41,7 @@ Added rules descriptions for No Metabolism, Undead Metabolism, and Spirit Bottle
 ### Agility Skills
 * Warbow Training, incant updated.
 * New Agile Proficiency: usable with Ranged Weapons and for Short Weapons from behind.
+* Mimicry cannot be used on level 10 Spells.
 
 ### Production Skills
 * Dispel Magic doesn't work on Glyphs


### PR DESCRIPTION
Added that Mimicry cannot be used on level 10 Spells.