### PR TITLE
Renamed status-effects to effects & removed metabolism placeholder.

### DIFF
--- a/rules-topics/21_effects.md
+++ b/rules-topics/21_effects.md
@@ -37,9 +37,6 @@ The Entrapment spell allows a caster the chance to capture the spirit of a targe
 * Must have a spirit that is **NOT** protected by a SPIRIT BOTTLE effect.
 * Must not crumble at 0 body.
 
-### Metabolism Clarification
->Pending.
-
 ### Shattering & Destroying
 Shattering or destroying containers that contain things does NOT affect the items within it.
 


### PR DESCRIPTION
Removed Metabolism placeholder.  This wasn't an effect, but was placed here because it is where other clarifications ended up in the past.  The metabolism information is now in life and death. Renamed status-effects file to effects to better reflect the section's use.