### PR TITLE
v6 Rules Changes - Partial

### DIFF
--- a/chapters/02.05_combat.md
+++ b/chapters/02.05_combat.md
@@ -98,7 +98,7 @@ Spell Strike, Physical Strike, Toxin Strike, and Aether Strike are all spells or
 - The ability is consumed immediately, and is only good for a single swing; if the player misses their target entirely, the ability is still expended.
 - Striked abilities are not blocked by shields or weapons. A strike that contacts the targets shield or weapons is a successful hit.
 
-### Blocking Weapons and Abilities
-Weapon blows may be blocked with a wielded shield or weapon, so long as the character has the skill to use to it when they attempt to block. Blocking without having the relevant skill or while skilless (ie, while [[Stunned]]) results in the player taking the hit as though they had not blocked it at all.
+### Blocking
+Weapon blows may be blocked with a wielded shield or weapon, so long as the character has the skill to use to it when they attempt to block. Blocking without having the relevant skill or while skilless (ie, while [[Stunned]]) results in the player taking the hit as though they had not blocked it at all. 
 
-Spells and abilities (anything delivered as Physical, Magic, Toxin, Aether, and their Strike equivalents) successfully lands on the target if the packet or weapon phys rep makes contact with any part of the target's body, clothing, held items, or possessions.
+Spells and abilities (anything delivered as Physical, Magic, Toxin, Aether, and their Strike equivalents) successfully lands on the target if the packet or weapon phys rep makes contact with any part of the target's body, clothing, held items, or possessions. In other words, it is not possible to block an ability or spell with a shield or weapon; only weapon blows (calls that start with a number, is in "5 Normal") can be blocked.


### PR DESCRIPTION
## Changelog v6.0.0
## Gameplay Changes
- **Physical and Physical Strike**-delivered effects and abilities cannot be blocked by shields. **Physical** now follows the same rules as Magic-delivered and Spell Strike-delivered effects.
    - _(The purpose is not to change game balance at all, but to homogenize the rules and reduce unnecessary exceptions. Stat cards will be adjusted to accommodate this change; something that previously had a "Physical Kneel" will have it replaced with something like "1 Normal Kneel", which is still blockable.)_
- The Stamina ability **Regenerate** is only self-cast. The power of positive thinking helps you heal you, doesn't do nothin' for your friends.
- The Pain spell has been moved from 8th level Spirit to 10th level Spirit.
- Limited Phylactery has been removed.
- Paralytic Plague has been removed.
- **Incorporeal**: The character gains a free Additional Defense Slot that may only be used for Resist Physical. The character must concentrate for 3 seconds to physically interact with any physical objects. This does not apply to weapon blows, physical abilities, or performing First Aid.

## Character Stat Changes
- Removed the 5 "free" armor that was granted only if you purchased Armor Training or Dexterity Armor.


## Aesthetic / Cosmetic Changes
- Added "Free Skills" quasi-skillset for things like Identify, Tap Reserves, and Meditate